### PR TITLE
Case-Insensitive Filesystem Support

### DIFF
--- a/spec/new_spec.cr
+++ b/spec/new_spec.cr
@@ -1,15 +1,20 @@
 require "./spec_helper"
 
 describe Terminfo do
-  data = Terminfo::Data.new path: "/lib/terminfo/x/xterm" # Not accurate on macOS, fails
+  # Load terminfo file
+  data = Terminfo::Data.new path: "./filesystem/xterm"
   data.name.should eq "xterm"
 
+  # Load terminfo from system
   data = Terminfo::Data.new term: "xterm-256color"
   data.name.should eq "xterm-256color"
 
+  # Load terminfo from built-in
   data = Terminfo::Data.new builtin: "windows-ansi"
   data.name.should eq "ansi"
 
+  # Load terminfo via autodetect
+  expected_term = ENV["TERM"] || "xterm"
   data = Terminfo::Data.new
-  data.name.should eq "xterm"
+  data.name.should eq expected_term
 end

--- a/spec/new_spec.cr
+++ b/spec/new_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 describe Terminfo do
-  data = Terminfo::Data.new path: "/lib/terminfo/x/xterm"
+  data = Terminfo::Data.new path: "/lib/terminfo/x/xterm" # Not accurate on macOS, fails
   data.name.should eq "xterm"
 
   data = Terminfo::Data.new term: "xterm-256color"
@@ -9,9 +9,6 @@ describe Terminfo do
 
   data = Terminfo::Data.new builtin: "windows-ansi"
   data.name.should eq "ansi"
-
-  data = Terminfo::Data.new
-  data.name.should eq "xterm"
 
   data = Terminfo::Data.new
   data.name.should eq "xterm"

--- a/src/terminfo.cr
+++ b/src/terminfo.cr
@@ -607,8 +607,7 @@ module Terminfo
         File.join(dir, term[0..0], term[0..1], term),         # /path/to/terminfo/s/sc/screen
         File.join(dir, sprintf("%x", term[0..0].bytes), term) # /path/to/terminfo/73/screen, see https://invisible-island.net/ncurses/NEWS.html#t20071117
       ]
-      filename = locations.select{|loc| File.readable? loc}.pop?
-      break if filename
+      break if filename = locations.find{|loc| File.readable? loc}
     end
 
     if filename

--- a/src/terminfo.cr
+++ b/src/terminfo.cr
@@ -600,26 +600,25 @@ module Terminfo
   # :ditto:
   def initialize(*, term : String, extended = true)
     filename = nil
+    # scan all possible locations
     ::Terminfo.directories.each do |dir|
-      f1 = File.join dir, term
-      f2 = File.join dir, term[0..0], term[0..1], term
-      filename = nil
-      if File.readable? f1
-        filename = f1
-        break
-      elsif File.readable? f2
-        filename = f2
-        break
-      end
-      if filename
-        initialize path: filename, extended: extended
+      locations = [
+        File.join(dir, term),                                 # /path/to/terminfo/screen
+        File.join(dir, term[0..0], term[0..1], term),         # /path/to/terminfo/s/sc/screen
+        File.join(dir, sprintf("%x", term[0..0].bytes), term) # /path/to/terminfo/73/screen, see https://invisible-island.net/ncurses/NEWS.html#t20071117
+      ]
+      filename = locations.select{|loc| File.readable? loc}.pop?
+      break if filename
+    end
+
+    if filename
+      initialize path: filename, extended: extended
+    else
+      f = ::Terminfo.get_internal? term
+      if f
+        initialize file: f, extended: extended
       else
-        f = ::Terminfo.get_internal? term
-        if f
-          initialize file: f, extended: extended
-        else
-          raise Exception.new "Can't find system or builtin terminfo file for '#{term}'"
-        end
+        raise Exception.new "Can't find system or builtin terminfo file for '#{term}'"
       end
     end
   end


### PR DESCRIPTION
On case-insensitive filesystems (common for macOS), terminfo databases are stored under a different directory structure utilizing a [two-character (hexadecimal) representation of the terminal name's first character](https://invisible-island.net/ncurses/NEWS.html#t20071117).

This PR adds support for this directory structure while refactoring. This was done against the latest version of Crystal (0.34.0 at the time of this PR). I'm fairly new to Crystal, so please let me know if I should be targeting a different version.